### PR TITLE
remove warning

### DIFF
--- a/people_recognition_2d/scripts/people_recognition_2d_node
+++ b/people_recognition_2d/scripts/people_recognition_2d_node
@@ -11,10 +11,10 @@ from sensor_msgs.msg import Image
 class PeopleRecognition2DNode:
     def __init__(self):
 
-        openpose_srv_name = self._get_param('~openpose_srv_name', "openpose/recognize")
-        openface_srv_name = self._get_param('~openface_srv_name', "face_recognition/recognize")
-        keras_srv_name = self._get_param('~keras_srv_name', "face_recognition/get_face_properties")
-        color_extractor_srv_name = self._get_param('~color_extractor_srv_name', "extract_color")
+        openpose_srv_name = rospy.get_param('~openpose_srv_name', "openpose/recognize")
+        openface_srv_name = rospy.get_param('~openface_srv_name', "face_recognition/recognize")
+        keras_srv_name = rospy.get_param('~keras_srv_name', "face_recognition/get_face_properties")
+        color_extractor_srv_name = rospy.get_param('~color_extractor_srv_name', "extract_color")
 
         self._people_recognizer = PeopleRecognizer2D(openpose_srv_name,
                                                      openface_srv_name,
@@ -28,14 +28,6 @@ class PeopleRecognition2DNode:
         self._cv_bridge = CvBridge()
         self._result_image_publisher = rospy.Publisher('~result_image', Image, queue_size=1)
         rospy.loginfo("PeopleRecognitionNode initialized")
-
-    @staticmethod
-    def _get_param(name, default):
-        if rospy.has_param(name):
-            return rospy.get_param(name)
-        else:
-            rospy.logwarn('parameter %s not set, using the default value of %s', name, default)
-            return rospy.get_param(name, default)
 
     def _detect_people_srv(self, req):
         """

--- a/people_recognition_3d/scripts/people_recognition_3d_node
+++ b/people_recognition_3d/scripts/people_recognition_3d_node
@@ -16,20 +16,20 @@ from people_recognition_msgs.srv import RecognizePeople3D, RecognizePeople3DResp
 
 class PeopleRecognition3DNode:
     def __init__(self):
-        recognize_people_srv_name = self._get_param(
+        recognize_people_srv_name = rospy.get_param(
             '~recognize_people_srv_name', "detect_people")
         probability_threshold = float(
-            self._get_param('~probability_threshold', 0.2))
-        link_threshold = float(self._get_param('~link_threshold', 0.5))
-        heuristic = self._get_param('~heuristic', 'shoulder')
-        arm_norm_threshold = self._get_param('~arm_norm_threshold', 0.5)
-        neck_norm_threshold = self._get_param('~neck_norm_threshold', 0.7)
-        wave_threshold = self._get_param('~wave_threshold', 0.2)
-        vert_threshold = self._get_param('~vert_threshold', 0.7)
-        hor_threshold = self._get_param('~hor_threshold', 0.4)
-        padding = self._get_param('~padding', 5)
+            rospy.get_param('~probability_threshold', 0.2))
+        link_threshold = float(rospy.get_param('~link_threshold', 0.5))
+        heuristic = rospy.get_param('~heuristic', 'shoulder')
+        arm_norm_threshold = rospy.get_param('~arm_norm_threshold', 0.5)
+        neck_norm_threshold = rospy.get_param('~neck_norm_threshold', 0.7)
+        wave_threshold = rospy.get_param('~wave_threshold', 0.2)
+        vert_threshold = rospy.get_param('~vert_threshold', 0.7)
+        hor_threshold = rospy.get_param('~hor_threshold', 0.4)
+        padding = rospy.get_param('~padding', 5)
 
-        enable_topic_mode = self._get_param('~enable_topic_mode', False)
+        enable_topic_mode = rospy.get_param('~enable_topic_mode', False)
 
         self._people_recognizer_3d = PeopleRecognizer3D(
             recognize_people_srv_name, probability_threshold, link_threshold,
@@ -73,16 +73,6 @@ class PeopleRecognition3DNode:
             self._recognize_people_3d_srv)
 
         rospy.loginfo("PeopleRecognition3DNode initialized:")
-
-    @staticmethod
-    def _get_param(name, default):
-        if rospy.has_param(name):
-            return rospy.get_param(name)
-        else:
-            rospy.logwarn(
-                'parameter %s not set, using the default value of %s', name,
-                default)
-            return rospy.get_param(name, default)
 
     def _recognize_people_3d_srv(self, req):
         """


### PR DESCRIPTION
The warnings coming from the _get_param function are not helping. We have been using the default parameters for over a year without issue.
If we want to keep these warnings please suggest where to place a config file for them. 